### PR TITLE
Show correct guild count in /debug about

### DIFF
--- a/src/interactions/Debug/about.ts
+++ b/src/interactions/Debug/about.ts
@@ -24,7 +24,7 @@ export default async function (
             },
             {
                 name: 'Guild Count',
-                value: `${(await interaction.client.guilds.fetch()).size}`,
+                value: `${interaction.client.guilds.cache.size}`,
                 inline: true,
             },
             {


### PR DESCRIPTION
`/debug about`'s guild count is currently capped at 200. I assume this is a limitation of `Client.guilds.fetch()`, based on the fact that the optional `limit` parameter for `FetchGuildsOptions` seems to have a maximum value of 200 (see https://discord.js.org/docs/packages/discord.js/14.14.1/FetchGuildsOptions:Interface#limit). 

As far as I can tell, it is officially recommended by Discord.js maintainers to get the size of `Client.guilds.cache` instead. You also already do that for the bot's custom status message and... somewhere else that I can't remember. So this makes things consistent too! :P